### PR TITLE
Reset prometheus vectors every resync-interval.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -22,3 +22,16 @@ pipeline:
       - latest
     when:
       event: push
+
+  publish-tag:
+    image: plugins/ecr
+    secrets: [ecr_access_key, ecr_secret_key, ecr_registry]
+    registry: ${ECR_REGISTRY}
+    repo: ${ECR_REGISTRY}devops/${DRONE_REPO_NAME}
+    create_repository: true
+    tags:
+      - git-${DRONE_COMMIT_SHA:0:7}
+      - ${DRONE_TAG}
+      - latest
+    when:
+      event: tag

--- a/eventrouter.go
+++ b/eventrouter.go
@@ -151,24 +151,19 @@ func (er *EventRouter) updateEvent(objOld interface{}, objNew interface{}) {
 
 	// Detect if the Informer is in resync
 	// In a re-sync previous events are re-submitted as updateEvents, which means  ResourceVersions will match between the eOld and eNew.
-	// Since there could be legimtate k8s reasons to re-emit an event, we also check to see if the last
+	// Since there could be legitimate k8s reasons to re-emit an event, we also check to see if the last
 	// time vectors reset was at least X time ago as indicated by the resync interval.
 	if eOld.ResourceVersion == eNew.ResourceVersion {
-		reset := false
-
 		if er.lastReset.IsZero() || time.Since(er.lastReset) >= viper.GetDuration("resync-interval") {
 			glog.Info("Time since last reset: ", time.Since(er.lastReset))
 			er.lastReset = time.Now()
-			reset = true
-		}
-
-		if reset {
 			glog.Info("Reseting vectors")
 			kubernetesNormalEventCounterVec.Reset()
 			kubernetesInfoEventCounterVec.Reset()
 			kubernetesUnknownEventCounterVec.Reset()
 			kubernetesWarningEventCounterVec.Reset()
 		}
+
 		return
 	}
 

--- a/eventrouter.go
+++ b/eventrouter.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/heptiolabs/eventrouter/sinks"
@@ -52,6 +53,9 @@ type EventRouter struct {
 	// event sink
 	// TODO: Determine if we want to support multiple sinks.
 	eSink sinks.EventSinkInterface
+
+	// Keeps track of the last time the SharedInformer executed a re-sync
+	lastReset time.Time
 }
 
 // NewEventRouter will create a new event router using the input params
@@ -144,6 +148,30 @@ func (er *EventRouter) addEvent(obj interface{}) {
 func (er *EventRouter) updateEvent(objOld interface{}, objNew interface{}) {
 	eOld := objOld.(*v1.Event)
 	eNew := objNew.(*v1.Event)
+
+	// Detect if the Informer is in resync
+	// In a re-sync previous events are re-submitted as updateEvents, which means  ResourceVersions will match between the eOld and eNew.
+	// Since there could be legimtate k8s reasons to re-emit an event, we also check to see if the last
+	// time vectors reset was at least X time ago as indicated by the resync interval.
+	if eOld.ResourceVersion == eNew.ResourceVersion {
+		reset := false
+
+		if er.lastReset.IsZero() || time.Since(er.lastReset) >= viper.GetDuration("resync-interval") {
+			glog.Info("Time since last reset: ", time.Since(er.lastReset))
+			er.lastReset = time.Now()
+			reset = true
+		}
+
+		if reset {
+			glog.Info("Reseting vectors")
+			kubernetesNormalEventCounterVec.Reset()
+			kubernetesInfoEventCounterVec.Reset()
+			kubernetesUnknownEventCounterVec.Reset()
+			kubernetesWarningEventCounterVec.Reset()
+		}
+		return
+	}
+
 	prometheusEvent(eNew)
 	er.eSink.UpdateEvents(eNew, eOld)
 }


### PR DESCRIPTION
* Solves a memory leak as the eventrouter ingests more unique events from K8s.  The leak was forever increasing the size of the prometheus vectors and the labels.

* Prevents duplicate events from being re-scraped every re-sync interval.

A re-sync interval is a SharedInformer mechanic to insure that its local caches are up-to-date with the objects it is watching.